### PR TITLE
Fix parent call

### DIFF
--- a/src/Controller/MultiUploadController.php
+++ b/src/Controller/MultiUploadController.php
@@ -37,7 +37,7 @@ class MultiUploadController extends MediaAdminController
             ]);
         }
 
-        return parent::createAction();
+        return parent::createAction($request);
     }
 
     public function multiUploadAction(Request $request)


### PR DESCRIPTION
Fix: Call to a member function get() on null