### PR TITLE
Support for php 7.0

### DIFF
--- a/src/Form/MultiUploadType.php
+++ b/src/Form/MultiUploadType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MultiUploadType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('context', HiddenType::class, ['data' => $options['context'] ?? 'default'])
@@ -18,7 +18,7 @@ class MultiUploadType extends AbstractType
             ->add('binaryContent', FileType::class, ['attr' => ['multiple' => true]]);
     }
 
-    public function configureOptions(OptionsResolver $resolver): void
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => '',


### PR DESCRIPTION
With php 7.0:
Type error: Return value of SilasJoisten\Sonata\MultiUploadBundle\Form\MultiUploadType::configureOptions() must be an instance of SilasJoisten\Sonata\MultiUploadBundle\Form\void, none returned