### PR TITLE
Add fileExtension + mimetypes check on JS side

### DIFF
--- a/src/Controller/MultiUploadController.php
+++ b/src/Controller/MultiUploadController.php
@@ -58,6 +58,7 @@ class MultiUploadController extends MediaAdminController
             return $this->render('@SonataMultiUpload/multi_upload.html.twig', [
                 'action' => 'multi_upload',
                 'form' => $form->createView(),
+                'provider' => $provider,
             ]);
         }
 

--- a/src/Resources/views/multi_upload.html.twig
+++ b/src/Resources/views/multi_upload.html.twig
@@ -39,6 +39,8 @@
             $('div.{{ form.vars.id }}').dmUploader({
                 url: '{{ form.vars.action }}',
                 maxFileSize: 30000000000,
+                extFilter: {{ provider.allowedExtensions|json_encode|raw }},
+                allowedTypes: '{{ provider.allowedMimeTypes|join('|')|default('*') }}',
                 onDragEnter: function () {
                     $(this).css({'background-color': 'lightgray'});
                 },

--- a/src/Resources/views/multi_upload.html.twig
+++ b/src/Resources/views/multi_upload.html.twig
@@ -39,8 +39,12 @@
             $('div.{{ form.vars.id }}').dmUploader({
                 url: '{{ form.vars.action }}',
                 maxFileSize: 30000000000,
-                extFilter: {{ provider.allowedExtensions|json_encode|raw }},
-                allowedTypes: '{{ provider.allowedMimeTypes|join('|')|default('*') }}',
+                {% if provider.allowedExtensions is defined %}
+                    extFilter: {{ provider.allowedExtensions|json_encode|raw }},
+                {% endif %}
+                {% if provider.allowedMimeTypes is defined %}
+                    allowedTypes: '{{ provider.allowedMimeTypes|join('|')|default('*') }}',
+                {% endif %}
                 onDragEnter: function () {
                     $(this).css({'background-color': 'lightgray'});
                 },


### PR DESCRIPTION
This is a first fix of fileExtension checking issue raised in #16 

Before merging this one, we need to get the https://github.com/sonata-project/SonataMediaBundle/pull/1451 merged first.