### PR TITLE
Replace image preview path in controller

### DIFF
--- a/src/Controller/MultiUploadController.php
+++ b/src/Controller/MultiUploadController.php
@@ -5,6 +5,7 @@ namespace SilasJoisten\Sonata\MultiUploadBundle\Controller;
 use SilasJoisten\Sonata\MultiUploadBundle\Form\MultiUploadType;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\MediaBundle\Controller\MediaAdminController;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -63,6 +64,7 @@ class MultiUploadController extends MediaAdminController
             ]);
         }
 
+        /** @var MediaInterface $media */
         $media = $this->mediaManager->create();
         $media->setContext($context);
         $media->setBinaryContent($request->files->get('file'));
@@ -71,7 +73,7 @@ class MultiUploadController extends MediaAdminController
 
         return new JsonResponse([
             'status' => 'ok',
-            'path' => $provider->getCdnPath($provider->getReferenceImage($media), true),
+            'path' => $provider->getReferenceImage($media),
             'edit' => $this->admin->generateUrl('edit', ['id' => $media->getId()]),
         ]);
     }


### PR DESCRIPTION
I propose to remove the CdnPath method in the controller as I think it should be directly handled in the provider's getReferenceImage method. Thumbnails can be stored elsewhere than the cdn path.
Btw I don't know how to manage BC break... Any idea are welcome!