### PR TITLE
Fix the image preview for the imageProvider

### DIFF
--- a/src/Controller/MultiUploadController.php
+++ b/src/Controller/MultiUploadController.php
@@ -73,7 +73,7 @@ class MultiUploadController extends MediaAdminController
 
         return new JsonResponse([
             'status' => 'ok',
-            'path' => $provider->getReferenceImage($media),
+            'path' => $provider->generatePublicUrl($media, MediaProviderInterface::FORMAT_REFERENCE),
             'edit' => $this->admin->generateUrl('edit', ['id' => $media->getId()]),
         ]);
     }


### PR DESCRIPTION
Sorry but I fix here my mistake regarding the PR #36. Actually the change broke the image preview for the default imageProvider provided by SonataMediaBundle. By using the generatePublicUrl method there is no need to handle the cdn as it's handled directly in the imageProvider::generatePublicUrl method.
This way we have the same behavior than the code before the PR #36 merge but we have now the possibility to handle the reference image path directly in our CustomProvider class.