### PR TITLE
Add more flexibility by not decorating default controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ composer.lock
 
 .php-version
 .build/
+
+###> intellij IDE ###
+/.idea
+sonata-multiupload-bundle.iml
+###> intellij IDE ###

--- a/src/Admin/MultiUploadAdminExtension.php
+++ b/src/Admin/MultiUploadAdminExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SilasJoisten\Sonata\MultiUploadBundle\Admin;
 
+use SilasJoisten\Sonata\MultiUploadBundle\Controller\CreateController;
 use SilasJoisten\Sonata\MultiUploadBundle\Controller\MultiUploadController;
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -16,5 +17,9 @@ final class MultiUploadAdminExtension extends AbstractAdminExtension
         $collection->add('multi_upload', 'multi-upload', [
             '_controller' => sprintf('%s::multiUpload', MultiUploadController::class),
         ]);
+
+        $collection
+            ->get('create')
+            ->setDefault('_controller', sprintf('%s::createAction', CreateController::class));
     }
 }

--- a/src/Controller/CreateController.php
+++ b/src/Controller/CreateController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @phpstan-extends CRUDController<\Sonata\MediaBundle\Model\MediaInterface>
  */
-final class MediaAdminController extends CRUDController
+final class CreateController extends CRUDController
 {
     public function __construct(
         private Pool $pool,

--- a/src/Controller/MultiUploadController.php
+++ b/src/Controller/MultiUploadController.php
@@ -8,7 +8,6 @@ use OskarStark\Symfony\Http\Responder;
 use SilasJoisten\Sonata\MultiUploadBundle\Form\MultiUploadType;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\MediaBundle\Admin\ORM\MediaAdmin;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -22,7 +21,6 @@ final class MultiUploadController extends CRUDController
     public function __construct(
         private FormFactoryInterface $formFactory,
         private ManagerInterface $mediaManager,
-        private MediaAdmin $mediaAdmin,
         private Pool $mediaProviderPool,
         private Responder $responder,
         private int $maxUploadSize,
@@ -32,7 +30,7 @@ final class MultiUploadController extends CRUDController
 
     public function multiUpload(Request $request): Response
     {
-        $this->mediaAdmin->checkAccess('create');
+        $this->admin->checkAccess('create');
 
         $providerName = $request->query->get('provider');
         $context = $request->query->get('context', 'default');
@@ -61,7 +59,7 @@ final class MultiUploadController extends CRUDController
         return $this->responder->json([
             'status' => 'ok',
             'path' => $provider->generatePublicUrl($media, MediaProviderInterface::FORMAT_ADMIN),
-            'edit' => $this->mediaAdmin->generateUrl('edit', ['id' => $media->getId()]),
+            'edit' => $this->admin->generateUrl('edit', ['id' => $media->getId()]),
             'id' => $media->getId(),
         ]);
     }
@@ -70,7 +68,7 @@ final class MultiUploadController extends CRUDController
     {
         return $this->formFactory->create(MultiUploadType::class, null, [
             'data_class' => $this->mediaManager->getClass(),
-            'action' => $this->mediaAdmin->generateUrl('multi_upload', ['provider' => $provider->getName()]),
+            'action' => $this->admin->generateUrl('multi_upload', ['provider' => $provider->getName()]),
             'provider' => $provider->getName(),
             'context' => $context,
         ]);

--- a/src/Resources/config/controller.yaml
+++ b/src/Resources/config/controller.yaml
@@ -12,8 +12,7 @@ services:
         autowire: true
         public: true
 
-    SilasJoisten\Sonata\MultiUploadBundle\Controller\MediaAdminController:
-        decorates: 'sonata.media.controller.media.admin'
+    SilasJoisten\Sonata\MultiUploadBundle\Controller\CreateController:
         arguments: ['@sonata.media.pool']
         public: true
         tags: [ 'container.service_subscriber' ]

--- a/src/Resources/config/controller.yaml
+++ b/src/Resources/config/controller.yaml
@@ -2,7 +2,6 @@ services:
     SilasJoisten\Sonata\MultiUploadBundle\Controller\MultiUploadController:
         arguments:
             $mediaManager: '@sonata.media.manager.media'
-            $mediaAdmin: '@sonata.media.admin.media'
             $mediaProviderPool: '@sonata.media.pool'
             $maxUploadSize: '%sonata_multi_upload.max_upload_filesize%'
             $redirectTo: '%sonata_multi_upload.redirect_to%'


### PR DESCRIPTION
This will allow to override the create method even if we are using another controller for the admin.

Also the decorates is not implemented properly since you must call all the methods of the original decorated controller (the MediaAdminController does override the listAction).

It's better to not decorate in this case.