### PR TITLE
Fix: Prevent render Multiupload in Collection Modal

### DIFF
--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -23,7 +23,7 @@ final class MediaAdminController extends CRUDController
     {
         $this->admin->checkAccess('create');
 
-        if (null !== $request->query->get('pcode')) {
+        if (null !== $request->query->get('pcode') &&  $request->isXmlHttpRequest()) {
             return $this->renderWithExtraParams('@SonataMedia/MediaAdmin/select_provider.html.twig', [
                 'providers' => $this->pool->getProvidersByContext(
                     $request->get('context', $this->pool->getDefaultContext())

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -23,6 +23,15 @@ final class MediaAdminController extends CRUDController
     {
         $this->admin->checkAccess('create');
 
+        if (null !== $request->query->get('pcode')) {
+            return $this->renderWithExtraParams('@SonataMedia/MediaAdmin/select_provider.html.twig', [
+                'providers' => $this->pool->getProvidersByContext(
+                    $request->get('context', $this->pool->getDefaultContext())
+                ),
+                'action' => 'create',
+            ]);
+        }
+
         if (null === $request->get('provider') && $request->isMethod('get')) {
             return $this->renderWithExtraParams('@SonataMultiUpload/select_provider.html.twig', [
                 'providers' => $this->pool->getProvidersByContext(

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -23,7 +23,7 @@ final class MediaAdminController extends CRUDController
     {
         $this->admin->checkAccess('create');
 
-        if (null !== $request->query->get('pcode') &&  $request->isXmlHttpRequest()) {
+        if (null !== $request->query->get('pcode') && $request->isXmlHttpRequest()) {
             return $this->renderWithExtraParams('@SonataMedia/MediaAdmin/select_provider.html.twig', [
                 'providers' => $this->pool->getProvidersByContext(
                     $request->get('context', $this->pool->getDefaultContext())

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -23,7 +23,7 @@ final class MediaAdminController extends CRUDController
     {
         $this->admin->checkAccess('create');
 
-        if (null !== $request->query->get('pcode') && $request->isXmlHttpRequest()) {
+        if ($request->query->has('pcode') && $request->isXmlHttpRequest()) {
             return $this->renderWithExtraParams('@SonataMedia/MediaAdmin/select_provider.html.twig', [
                 'providers' => $this->pool->getProvidersByContext(
                     $request->get('context', $this->pool->getDefaultContext())


### PR DESCRIPTION
In this case i override the Add new button for this block:

![CleanShot 2022-05-15 at 10 42 25@2x](https://user-images.githubusercontent.com/10114981/168464534-f7f5ea00-c163-46c4-a799-c120057f0a28.png)

And i want the multi upload in this modal. So checking only for the `isXmlHttpRequest` is not the best option here. In Favor i check if in query the `pcode` isset.

Maybe there is a better way but i could not find one.

closes #73